### PR TITLE
CSSE1001 Fixes

### DIFF
--- a/src/main/java/chalkbox/collectors/BlackboardCollector.java
+++ b/src/main/java/chalkbox/collectors/BlackboardCollector.java
@@ -148,7 +148,9 @@ public class BlackboardCollector {
                 } else if (map[0].equals("\tFilename")) {
                     files.set(currentFile, map[1]);
                 } else {
-                    data.set(map[0], map[1]);
+                    if (!data.keys().contains(map[0])) {
+                        data.set(map[0], map[1]);
+                    }
                 }
                 // multi-line key
             } else if (line.contains(":")) {

--- a/src/main/java/chalkbox/collectors/BlackboardCollector.java
+++ b/src/main/java/chalkbox/collectors/BlackboardCollector.java
@@ -38,6 +38,9 @@ public class BlackboardCollector {
 
         for (ZipEntry entry : zip.stream().collect(Collectors.toList())) {
             if (entry.getName().endsWith(".txt")) {
+                if (entry.getName().split("_").length != 4) {
+                    continue;
+                }
                 Scanner s = new Scanner(zip.getInputStream(entry)).useDelimiter("\\A");
                 String result = s.hasNext() ? s.next() : "";
 

--- a/src/main/java/chalkbox/python/CSSE1001Test.java
+++ b/src/main/java/chalkbox/python/CSSE1001Test.java
@@ -36,6 +36,7 @@ public class CSSE1001Test {
 
         try {
             collection.getWorking().copyFolder(new File(included));
+            collection.getWorking().copyFolder(new File(collection.getSource().getUnmaskedPath()));
         } catch (IOException e) {
             feedback.set("test.error", "Unable to copy supplied directory");
             return collection;
@@ -43,7 +44,7 @@ public class CSSE1001Test {
 
         try {
             process = Execution.runProcess(working, environment, 10000,
-                    PYTHON, "-m", runner, "--json");
+                    PYTHON, runner, "--json");
         } catch (IOException e) {
             feedback.set("test.error", "IOException occurred");
             return collection;
@@ -56,6 +57,20 @@ public class CSSE1001Test {
         feedback.set("test", new Data(output));
 
         System.err.println(process.getError());
+
+        try {
+            process = Execution.runProcess(working, environment, 10000,
+                    PYTHON, runner);
+        } catch (IOException e) {
+            feedback.set("test.error", "IOException occurred");
+            return collection;
+        } catch (TimeoutException e) {
+            feedback.set("test.error", "Timed out executing tests");
+            return collection;
+        }
+
+        output = process.getOutput();
+        feedback.set("output", output);
 
         return collection;
     }


### PR DESCRIPTION
Addressing the issue raised by #15 

Addresses the problem by resolving the larger problem of chalkbox trying to read a students players.txt file as their submission information file.

Initially, chalkbox was looking for submission information files as any file ending with .txt, unfortunately, this lead to students who submitted .txt files outside of a zip to be read as a submission file. These files weren't in the correct blackboard submission format so it crashed.

Now chalkbox looks at only .txt files without a name (the presumed submission information files) which resolves the issue. The original way of parsing submission info files is kept as (while not the most informative) crashing is expected behaviour when finding a submission info file that's incorrectly formatted.

Additionally, this fixes multiple headers from overriding. "This is because some clever students in 2019s2a2-gradebook.zip have added their name in the same format as the submission information to their comments. As a sneaky fix, we're just saying that the first key/pair value in a submission zip is final. Ideally we would want to separate and escape student comments to prevent this from happening."

Finally, it also includes the plain text feedback from the test runs in the students data.