### PR TITLE
Config Parsing

### DIFF
--- a/src/main/java/chalkbox/api/config/BoxConfigParser.java
+++ b/src/main/java/chalkbox/api/config/BoxConfigParser.java
@@ -1,0 +1,113 @@
+package chalkbox.api.config;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An implementation of a configuration parser designed to work with
+ * key-value pair text files, known as boxes.
+ *
+ * Example format:
+ * <pre>
+*  key1=value1
+*  key2=value2
+*  key3=value3
+ * </pre>
+ */
+class BoxConfigParser implements ConfigParser {
+    /**
+     * Implementation of reading a box file.
+     *
+     * @param input The input stream to parse.
+     * @return The configuration as a configuration object.
+     * @throws ConfigParseException If the config file cannot be read.
+     */
+    @Override
+    public ChalkboxConfig read(InputStream input) throws ConfigParseException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+
+        Map<String, String> map = new HashMap<>();
+        int lineNumber = 0;
+        String line;
+        while (true) {
+            // Read the next line
+            try {
+                line = reader.readLine();
+                lineNumber++;
+            } catch (IOException e) {
+                throw new ConfigParseException("Unable to read line "
+                        + lineNumber, e);
+            }
+
+            // End of input
+            if (line == null) {
+                break;
+            }
+
+            // Skip comments
+            if (line.startsWith("#")) {
+                continue;
+            }
+
+            String[] parts = line.split("=", 2);
+
+            // Error a malformed line
+            if (parts.length < 2) {
+                throw new ConfigParseException("Line "
+                        + lineNumber + " doesn't have a key value assignment");
+            }
+            if (parts.length > 2) {
+                throw new ConfigParseException("Line "
+                        + lineNumber + " has multiple assignments and is ambiguous");
+            }
+
+            map.put(parts[0], parts[1]);
+        }
+
+        return new BoxChalkboxConfigImpl(map);
+    }
+
+    @Override
+    public ChalkboxConfig read(Path path) throws ConfigParseException {
+        try {
+            return read(new FileInputStream(path.toFile()));
+        } catch (FileNotFoundException e) {
+            throw new ConfigParseException("Unable to find the config file", e);
+        }
+    }
+
+    @Override
+    public ChalkboxConfig read(String configuration) throws ConfigParseException {
+        return read(new ByteArrayInputStream(configuration.getBytes()));
+    }
+
+    /**
+     * Implementation of a ChalkboxConfig that stores String key to String value
+     * mappings as a map.
+     */
+    private class BoxChalkboxConfigImpl implements ChalkboxConfig {
+        private final Map<String, String> config;
+
+        BoxChalkboxConfigImpl(Map<String, String> config) {
+            this.config = config;
+        }
+
+        @Override
+        public String value(String key) {
+            return config.get(key);
+        }
+
+        @Override
+        public boolean isSet(String key) {
+            return config.containsKey(key);
+        }
+    }
+}

--- a/src/main/java/chalkbox/api/config/BoxConfigParser.java
+++ b/src/main/java/chalkbox/api/config/BoxConfigParser.java
@@ -17,9 +17,9 @@ import java.util.Map;
  *
  * Example format:
  * <pre>
-*  key1=value1
-*  key2=value2
-*  key3=value3
+ * key1=value1
+ * key2=value2
+ * key3=value3
  * </pre>
  */
 class BoxConfigParser implements ConfigParser {
@@ -53,7 +53,7 @@ class BoxConfigParser implements ConfigParser {
             }
 
             // Skip comments
-            if (line.startsWith("#")) {
+            if (line.startsWith("#") || line.length() == 0) {
                 continue;
             }
 

--- a/src/main/java/chalkbox/api/config/BoxConfigParser.java
+++ b/src/main/java/chalkbox/api/config/BoxConfigParser.java
@@ -109,5 +109,10 @@ class BoxConfigParser implements ConfigParser {
         public boolean isSet(String key) {
             return config.containsKey(key);
         }
+
+        @Override
+        public Map<String, String> toMap() {
+            return new HashMap<>(config);
+        }
     }
 }

--- a/src/main/java/chalkbox/api/config/ChalkboxConfig.java
+++ b/src/main/java/chalkbox/api/config/ChalkboxConfig.java
@@ -1,0 +1,27 @@
+package chalkbox.api.config;
+
+/**
+ * Interface of the chalkbox configuration settings.
+ *
+ * Typically chalkbox config settings are loaded from a box file.
+ *
+ * {@link ChalkboxConfig} provides the interface for retrieving configuration
+ * values from a loaded configuration.
+ */
+public interface ChalkboxConfig {
+    /**
+     * Retrieve the value for the provided key value.
+     *
+     * @param key A key value to look for in the configuration.
+     * @return The value or null if not assigned a value.
+     */
+    String value(String key);
+
+    /**
+     * Determine whether a configuration value has been set for the given key.
+     *
+     * @param key A key value to look for in the configuration.
+     * @return True if a value has been assigned to the given key, else False.
+     */
+    boolean isSet(String key);
+}

--- a/src/main/java/chalkbox/api/config/ChalkboxConfig.java
+++ b/src/main/java/chalkbox/api/config/ChalkboxConfig.java
@@ -1,5 +1,7 @@
 package chalkbox.api.config;
 
+import java.util.Map;
+
 /**
  * Interface of the chalkbox configuration settings.
  *
@@ -24,4 +26,14 @@ public interface ChalkboxConfig {
      * @return True if a value has been assigned to the given key, else False.
      */
     boolean isSet(String key);
+
+    /**
+     * Convert the configuration into a map of string keys to string values.
+     *
+     * <strong>This type of map is the default input to processors so this is
+     * an important requiredment.</strong>
+     *
+     * @return A chalkbox config converted into a mapping from keys to values.
+     */
+    Map<String, String> toMap();
 }

--- a/src/main/java/chalkbox/api/config/ConfigParseException.java
+++ b/src/main/java/chalkbox/api/config/ConfigParseException.java
@@ -1,0 +1,11 @@
+package chalkbox.api.config;
+
+public class ConfigParseException extends Exception {
+    public ConfigParseException(String message) {
+        super(message);
+    }
+
+    public ConfigParseException(String message, Exception exception) {
+        super(message, exception);
+    }
+}

--- a/src/main/java/chalkbox/api/config/ConfigParser.java
+++ b/src/main/java/chalkbox/api/config/ConfigParser.java
@@ -9,12 +9,7 @@ import java.nio.file.Path;
  * Example usage: Parsing a box file called mybox.box in the working directory.
  * {@code
  * ConfigParser parser = ConfigParser.box();
- * ChalkboxConfig config = parser.read(Path.from("./mybox.box"));
- *
- * // Don't forget to check for errors
- * if (config == null) {
- *     log(config.errors());
- * }
+ * ChalkboxConfig config = parser.read(Paths.of("./mybox.box"));
  * }
  */
 public interface ConfigParser {
@@ -22,7 +17,7 @@ public interface ConfigParser {
      * @return An instance of config parser designed for parsing box files.
      */
     static ConfigParser box() {
-        return null;
+        return new BoxConfigParser();
     }
 
     /**

--- a/src/main/java/chalkbox/api/config/ConfigParser.java
+++ b/src/main/java/chalkbox/api/config/ConfigParser.java
@@ -1,0 +1,57 @@
+package chalkbox.api.config;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Interface for loading configuration information.
+ *
+ * Example usage: Parsing a box file called mybox.box in the working directory.
+ * {@code
+ * ConfigParser parser = ConfigParser.box();
+ * ChalkboxConfig config = parser.read(Path.from("./mybox.box"));
+ *
+ * // Don't forget to check for errors
+ * if (config == null) {
+ *     log(config.errors());
+ * }
+ * }
+ */
+public interface ConfigParser {
+    /**
+     * @return An instance of config parser designed for parsing box files.
+     */
+    static ConfigParser box() {
+        return null;
+    }
+
+    /**
+     * Parse the config from an input stream.
+     *
+     * @param input The input stream to parse.
+     * @return The loaded configuration.
+     *
+     * @throws ConfigParseException If the config can't be parsed for some reason.
+     */
+    ChalkboxConfig read(InputStream input) throws ConfigParseException;
+
+    /**
+     * Parse the config from a file at a given path.
+     *
+     * @param path The path of the file to parse.
+     * @return The loaded configuration.
+     *
+     * @throws ConfigParseException If the config can't be parsed for some reason.
+     */
+    ChalkboxConfig read(Path path) throws ConfigParseException;
+
+    /**
+     * Parse the config from a string representation of the configuration.
+     *
+     * @param configuration The string of the configuration.
+     * @return The loaded configuration.
+     *
+     * @throws ConfigParseException If the config can't be parsed for some reason.
+     */
+    ChalkboxConfig read(String configuration) throws ConfigParseException;
+}

--- a/src/test/java/chalkbox/api/config/BoxConfigParserTest.java
+++ b/src/test/java/chalkbox/api/config/BoxConfigParserTest.java
@@ -1,0 +1,102 @@
+package chalkbox.api.config;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+
+public class BoxConfigParserTest {
+
+    private static final String SIMPLE_CONFIG = new StringBuilder()
+            .append("key1=value1")
+            .append("key2=value2")
+            .append("key3=value3")
+            .append("mykey=hello")
+            .append("theirs=world")
+            .toString();
+
+    @Test(expected = ConfigParseException.class)
+    public void testError() throws ConfigParseException {
+        ConfigParser parser = ConfigParser.box();
+        parser.read("invalid information");
+    }
+
+    @Test
+    public void testStringReadBasicValue() throws ConfigParseException {
+        ConfigParser parser = ConfigParser.box();
+        ChalkboxConfig config = parser.read(SIMPLE_CONFIG);
+        basicValue(config);
+    }
+
+    @Test
+    public void testStringReadBasicIsSet() throws ConfigParseException {
+        ConfigParser parser = ConfigParser.box();
+        ChalkboxConfig config = parser.read(SIMPLE_CONFIG);
+        basicIsSet(config);
+    }
+
+    @Test
+    public void testStreamReadBasicValue() throws ConfigParseException {
+        InputStream stream = new ByteArrayInputStream(SIMPLE_CONFIG.getBytes());
+
+        ConfigParser parser = ConfigParser.box();
+        ChalkboxConfig config = parser.read(stream);
+        basicValue(config);
+    }
+
+    @Test
+    public void testStreamReadBasicIsSet() throws ConfigParseException {
+        InputStream stream = new ByteArrayInputStream(SIMPLE_CONFIG.getBytes());
+
+        ConfigParser parser = ConfigParser.box();
+        ChalkboxConfig config = parser.read(stream);
+        basicIsSet(config);
+    }
+
+    @Test
+    public void testPathReadBasicValue()
+            throws ConfigParseException, IOException {
+        File file = File.createTempFile("testPathReadBasicValue", ".box");
+        file.deleteOnExit();
+
+        ConfigParser parser = ConfigParser.box();
+        ChalkboxConfig config = parser.read(file.getPath());
+        basicValue(config);
+    }
+
+    @Test
+    public void testPathReadBasicIsSet()
+            throws ConfigParseException, IOException {
+        File file = File.createTempFile("testPathReadBasicIsSet", ".box");
+        file.deleteOnExit();
+
+        ConfigParser parser = ConfigParser.box();
+        ChalkboxConfig config = parser.read(file.getPath());
+        basicValue(config);
+    }
+
+    private void basicValue(ChalkboxConfig config) {
+        assertEquals("value1", config.value("key1"));
+        assertEquals("value2", config.value("key2"));
+        assertEquals("value3", config.value("key3"));
+        assertEquals("hello", config.value("mykey"));
+        assertEquals("world", config.value("theirs"));
+    }
+
+    private void basicIsSet(ChalkboxConfig config) throws ConfigParseException {
+        assertTrue(config.isSet("key1"));
+        assertTrue(config.isSet("key2"));
+        assertTrue(config.isSet("key3"));
+        assertTrue(config.isSet("mykey"));
+        assertTrue(config.isSet("theirs"));
+
+        assertFalse(config.isSet("key0"));
+        assertFalse(config.isSet("key4"));
+        assertFalse(config.isSet("hello"));
+        assertFalse(config.isSet("world"));
+    }
+}

--- a/src/test/java/chalkbox/api/config/BoxConfigParserTest.java
+++ b/src/test/java/chalkbox/api/config/BoxConfigParserTest.java
@@ -4,19 +4,21 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 
 import static org.junit.Assert.*;
 
 public class BoxConfigParserTest {
 
     private static final String SIMPLE_CONFIG = new StringBuilder()
-            .append("key1=value1")
-            .append("key2=value2")
-            .append("key3=value3")
-            .append("mykey=hello")
-            .append("theirs=world")
+            .append("key1=value1\n")
+            .append("key2=value2\n")
+            .append("key3=value3\n")
+            .append("mykey=hello\n")
+            .append("theirs=world\n")
             .toString();
 
     @Test(expected = ConfigParseException.class)
@@ -61,10 +63,13 @@ public class BoxConfigParserTest {
     public void testPathReadBasicValue()
             throws ConfigParseException, IOException {
         File file = File.createTempFile("testPathReadBasicValue", ".box");
+        OutputStream stream = new FileOutputStream(file);
+        stream.write(SIMPLE_CONFIG.getBytes());
+        stream.flush();
         file.deleteOnExit();
 
         ConfigParser parser = ConfigParser.box();
-        ChalkboxConfig config = parser.read(file.getPath());
+        ChalkboxConfig config = parser.read(file.toPath());
         basicValue(config);
     }
 
@@ -72,10 +77,13 @@ public class BoxConfigParserTest {
     public void testPathReadBasicIsSet()
             throws ConfigParseException, IOException {
         File file = File.createTempFile("testPathReadBasicIsSet", ".box");
+        OutputStream stream = new FileOutputStream(file);
+        stream.write(SIMPLE_CONFIG.getBytes());
+        stream.flush();
         file.deleteOnExit();
 
         ConfigParser parser = ConfigParser.box();
-        ChalkboxConfig config = parser.read(file.getPath());
+        ChalkboxConfig config = parser.read(file.toPath());
         basicValue(config);
     }
 

--- a/src/test/java/chalkbox/api/config/BoxConfigParserTest.java
+++ b/src/test/java/chalkbox/api/config/BoxConfigParserTest.java
@@ -8,6 +8,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -95,7 +97,7 @@ public class BoxConfigParserTest {
         assertEquals("world", config.value("theirs"));
     }
 
-    private void basicIsSet(ChalkboxConfig config) throws ConfigParseException {
+    private void basicIsSet(ChalkboxConfig config) {
         assertTrue(config.isSet("key1"));
         assertTrue(config.isSet("key2"));
         assertTrue(config.isSet("key3"));
@@ -106,5 +108,20 @@ public class BoxConfigParserTest {
         assertFalse(config.isSet("key4"));
         assertFalse(config.isSet("hello"));
         assertFalse(config.isSet("world"));
+    }
+
+    @Test
+    public void testMapConversion() throws ConfigParseException {
+        ConfigParser parser = ConfigParser.box();
+        ChalkboxConfig config = parser.read(SIMPLE_CONFIG);
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("key1", "value1");
+        expected.put("key2", "value2");
+        expected.put("key3", "value3");
+        expected.put("mykey", "hello");
+        expected.put("theirs", "world");
+
+        assertEquals(expected, config.toMap());
     }
 }


### PR DESCRIPTION
Implemented a robust way to parse config files.

This allows for the type of config file to be easily changed behind the scenes into different, more standardised formats such as JSON or YAML (*cough* @wisebaldone *cough*).

Just make your own ConfigParser implementation like in BoxConfigParser.