### PR TITLE
Bug Fixes & Platform Independence

### DIFF
--- a/src/main/java/chalkbox/java/test/IndividualJavaTest.java
+++ b/src/main/java/chalkbox/java/test/IndividualJavaTest.java
@@ -10,10 +10,10 @@ import chalkbox.api.collections.Data;
 import chalkbox.api.common.java.JUnitRunner;
 import chalkbox.api.files.FileLoader;
 import chalkbox.java.compilation.IndividualJavaCompiler;
-import org.json.simple.JSONObject;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,9 +24,6 @@ import java.util.Map;
  */
 @Processor(depends = {IndividualJavaCompiler.class})
 public class IndividualJavaTest extends JavaTest {
-    @ConfigItem(key = "temp", description = "A temporary output directory")
-    public String tempResults;
-
     @ConfigItem(key = "included", required = false,
             description = "Folder containing files to include in submission working directory when running tests")
     public File included = null;
@@ -37,8 +34,18 @@ public class IndividualJavaTest extends JavaTest {
 
     @Prior
     public void buildClassPath(Map<String, String> config) {
-        File solutionFolder = new File(tempResults + File.separator + "solution");
+        /* Create a new temporary directory for compilation output */
+        Bundle compilationOutput;
+        Bundle solutionBundle;
+        try {
+            compilationOutput = new Bundle();
+            solutionBundle = compilationOutput.makeBundle("solution");
+        } catch (IOException e) {
+            System.err.println("Unable to create compilation output directory");
+            return;
+        }
 
+        File solutionFolder = Paths.get(solutionBundle.getUnmaskedPath()).toFile();
         File[] classes = solutionFolder.listFiles();
         for (File clazz : classes) {
             classPaths.put(FileLoader.truncatePath(solutionFolder, clazz), clazz.getPath());

--- a/src/main/java/chalkbox/java/test/IndividualJavaTest.java
+++ b/src/main/java/chalkbox/java/test/IndividualJavaTest.java
@@ -27,6 +27,10 @@ public class IndividualJavaTest extends JavaTest {
     @ConfigItem(key = "temp", description = "A temporary output directory")
     public String tempResults;
 
+    @ConfigItem(key = "included", required = false,
+            description = "Folder containing files to include in submission working directory when running tests")
+    public File included = null;
+
     private Map<String, String> classPaths = new HashMap<>();
 
     private Bundle tests;
@@ -50,7 +54,9 @@ public class IndividualJavaTest extends JavaTest {
         }
 
         try {
-            submission.getWorking().copyFolder(new File("."));
+            if (included != null) {
+                submission.getWorking().copyFolder(included);
+            }
         } catch (IOException e) {
             submission.getResults().set("tests.error.errors",
                     "Unable to populate working directory");

--- a/src/main/java/chalkbox/python/CSSE1001Test.java
+++ b/src/main/java/chalkbox/python/CSSE1001Test.java
@@ -39,6 +39,7 @@ public class CSSE1001Test {
             collection.getWorking().copyFolder(included);
             collection.getWorking().copyFolder(new File(collection.getSource().getUnmaskedPath()));
         } catch (IOException e) {
+            e.printStackTrace();
             feedback.set("test.error", "Unable to copy supplied directory");
             return collection;
         }

--- a/src/main/java/chalkbox/python/CSSE1001Test.java
+++ b/src/main/java/chalkbox/python/CSSE1001Test.java
@@ -22,21 +22,21 @@ public class CSSE1001Test {
     public String PYTHON = "python3";
 
     @ConfigItem(key = "runner", description = "Name of the test runner")
-    public String runner;
+    public File runner;
 
     @ConfigItem(key = "included", description = "Path to supplied assignment files")
-    public String included;
+    public File included;
 
     @Pipe
     public Collection run(Collection collection) {
         Data feedback = collection.getResults();
         ProcessExecution process;
         Map<String, String> environment = new HashMap<>();
-        environment.put("PYTHONPATH", included);
+        environment.put("PYTHONPATH", included.getPath());
         File working = new File(collection.getWorking().getUnmaskedPath());
 
         try {
-            collection.getWorking().copyFolder(new File(included));
+            collection.getWorking().copyFolder(included);
             collection.getWorking().copyFolder(new File(collection.getSource().getUnmaskedPath()));
         } catch (IOException e) {
             feedback.set("test.error", "Unable to copy supplied directory");
@@ -45,7 +45,7 @@ public class CSSE1001Test {
 
         try {
             process = Execution.runProcess(working, environment, 10000,
-                    PYTHON, runner, "--json");
+                    PYTHON, runner.getPath(), "--json");
         } catch (IOException e) {
             System.err.println("Error occurred trying to spawn the test runner process (in json mode)");
             e.printStackTrace();
@@ -63,7 +63,7 @@ public class CSSE1001Test {
 
         try {
             process = Execution.runProcess(working, environment, 10000,
-                    PYTHON, runner);
+                    PYTHON, runner.getPath());
         } catch (IOException e) {
             System.err.println("Error occurred trying to spawn the test runner process");
             e.printStackTrace();

--- a/src/main/java/chalkbox/python/PythonUnitTest.java
+++ b/src/main/java/chalkbox/python/PythonUnitTest.java
@@ -13,9 +13,9 @@ import java.util.concurrent.TimeoutException;
 @Processor
 public class PythonUnitTest {
 
-    @Pipe(stream = "submissions")
+    @Pipe
     public Collection run(Collection collection) {
-        File working = new File(collection.getSource().getUnmaskedPath(""));
+        File working = new File(collection.getSource().getUnmaskedPath());
         String output = collection.getWorking().getUnmaskedPath("results.json");
 
         try {

--- a/src/main/java/chalkbox/python/Splat.java
+++ b/src/main/java/chalkbox/python/Splat.java
@@ -10,6 +10,7 @@ import chalkbox.api.common.ProcessExecution;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -21,14 +22,14 @@ public class Splat {
     public String PYTHON = "python3";
 
     @ConfigItem(key = "splat", description = "Path to splat executable")
-    public String splat;
+    public File splat;
 
-    @Pipe(stream = "submissions")
+    @Pipe
     public Collection run(Collection collection) {
         Data feedback = collection.getResults();
         Map<String, String> environment = new HashMap<>();
-        environment.put("PYTHONPATH", splat);
-        File working = new File(splat + File.separator + "splat_analysis");
+        environment.put("PYTHONPATH", splat.getPath());
+        File working = Paths.get(splat.getPath() + "/splat_analysis").toFile();
 
         ProcessExecution process;
         try {

--- a/src/test/java/chalkbox/api/config/FieldAssignmentTest.java
+++ b/src/test/java/chalkbox/api/config/FieldAssignmentTest.java
@@ -9,6 +9,7 @@ import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipFile;
@@ -104,8 +105,7 @@ public class FieldAssignmentTest {
 
     @Test
     public void testFileAssignment() {
-        String file = "src" + File.separator + "test" + File.separator + "resources"
-                      + File.separator + "csse1001" + File.separator + "test.box";
+        String file = Paths.get("src/test/resources/csse1001/test.box").toString();
         boolean result = assign("fileField", file);
 
         assertTrue(result);
@@ -121,7 +121,7 @@ public class FieldAssignmentTest {
             assertFalse(result);
         });
 
-        assertEquals("Unable to find file: nosuchfile\n", out);
+        assertEquals("Unable to find file: nosuchfile" + System.lineSeparator(), out);
         assertNull(instance.fileField);
     }
 
@@ -140,9 +140,14 @@ public class FieldAssignmentTest {
             assertFalse(result);
         });
 
-        assertEquals("Invalid enum value for enum: class chalkbox.api.config.FieldAssignmentTest$TestEnum\n" +
-                "Value enum values are: [IN_ENUM, A, B, C]\n" +
-                "Found: NOT_IN_ENUM\n", out);
+        assertEquals(
+                "Invalid enum value for enum: class chalkbox.api.config.FieldAssignmentTest$TestEnum"
+                        + System.lineSeparator() +
+                        "Value enum values are: [IN_ENUM, A, B, C]"
+                        + System.lineSeparator() +
+                        "Found: NOT_IN_ENUM"
+                        + System.lineSeparator(),
+                out);
         assertNull(instance.enumField);
     }
 
@@ -161,7 +166,7 @@ public class FieldAssignmentTest {
             assertFalse(result);
         });
 
-        assertEquals("Unable to cast not an int to integer\n", out);
+        assertEquals("Unable to cast not an int to integer" + System.lineSeparator(), out);
         assertEquals(0, instance.intField);
     }
 
@@ -185,7 +190,7 @@ public class FieldAssignmentTest {
             assertFalse(result);
         });
 
-        assertEquals("Unable to cast not a bool to boolean\n", out);
+        assertEquals("Unable to cast not a bool to boolean" + System.lineSeparator(), out);
         assertFalse(instance.booleanField);
     }
 
@@ -241,8 +246,7 @@ public class FieldAssignmentTest {
 
     @Test
     public void testZipAssignment() {
-        String file = "src" + File.separator + "test" + File.separator + "resources"
-                + File.separator + "csse1001" + File.separator + "test.box";
+        String file = Paths.get("src/test/resources/csse1001/gradebook.zip").toString();
         boolean result = assign("zipField", file);
 
         assertTrue(result);
@@ -251,27 +255,25 @@ public class FieldAssignmentTest {
 
     @Test
     public void testNoZipAssignment() {
-        String file = "src" + File.separator + "test" + File.separator + "resources"
-                + File.separator + "csse1001" + File.separator + "nozip.zip";
+        String file = Paths.get("src/test/resources/csse1001/nozip.zip").toString();
         String out = mockErrorStream(() -> {
             boolean result = assign("zipField", file);
             assertFalse(result);
         });
 
-        assertTrue(out.endsWith("IO Exception trying to read zip file\n"));
+        assertTrue(out.endsWith("IO Exception trying to read zip file" + System.lineSeparator()));
         assertNull(instance.zipField);
     }
 
     @Test
     public void testInvalidZipAssignment() {
-        String file = "src" + File.separator + "test" + File.separator + "resources"
-                + File.separator + "csse1001" + File.separator + "test.box";
+        String file = Paths.get("src/test/resources/csse1001/test.box").toString();
         String out = mockErrorStream(() -> {
             boolean result = assign("zipField", file);
             assertFalse(result);
         });
 
-        assertTrue(out.endsWith("Invalid zip file found\n"));
+        assertTrue(out.endsWith("Invalid zip file found" + System.lineSeparator()));
         assertNull(instance.zipField);
     }
 }


### PR DESCRIPTION
Performed various bug fixes to fix up hacks used during the semester. e.g. #1 and #12 

Additionally adjusted the tests to use platform-independent line separators and file separators.

Finally made use of the new ConfigItem field types to load file paths for CSSE1001Test in a platform-independent way (using Paths.get).